### PR TITLE
update replace pattern

### DIFF
--- a/library.js
+++ b/library.js
@@ -3,8 +3,8 @@
     var Soundcloud = {},
         embed = '<iframe width="100%" height="166" scrolling="no" frameborder="no" src="https://w.soundcloud.com/player/?url=https://soundcloud.com/$1/$2&amp;show_artwork=true"></iframe>',
         embeds = '<iframe width="100%" height="410" scrolling="no" frameborder="no" src="https://w.soundcloud.com/player/?url=https://soundcloud.com/$1/sets/$2&amp;show_artwork=true"></iframe>'
-    var	embedtrack = /<a href="(?:https?:\/\/)?(?:www\.)?(?:soundcloud\.com)\/?([\w\-_]+)\/([\w\-_]+)">.+<\/a>/g;
-    var	embedset = /<a href="(?:https?:\/\/)?(?:www\.)?(?:soundcloud\.com)\/?([\w\-_]+)\/sets\/([\w\-_]+)">.+<\/a>/g;
+    var	embedtrack = /<a href="(?:https?:\/\/)?(?:www\.)?(?:soundcloud\.com)\/?([\w\-_]+)\/([\w\-_]+)" .+>.+<\/a>/g;
+    var	embedset = /<a href="(?:https?:\/\/)?(?:www\.)?(?:soundcloud\.com)\/?([\w\-_]+)\/sets\/([\w\-_]+)" .+>.+<\/a>/g;
 
 
     Soundcloud.parse = function(data, callback) {


### PR DESCRIPTION
in many case, if `<a ...>` had some attribute, but `href` is belongs soundcloud, it would not work at all.

so update pattern for parsing.
